### PR TITLE
Remove V1 TVL Home Page Conflict

### DIFF
--- a/src/views/Home/Home.tsx
+++ b/src/views/Home/Home.tsx
@@ -102,7 +102,7 @@ const Home: React.FC = () => {
         </CTACards>
         <Cards>
           <CakeStats />
-          <TotalValueLockedCard />
+         {/* <TotalValueLockedCard /> */}
         </Cards>
       </div>
     </Page>


### PR DESCRIPTION
TVL calculation will no longer work with PCS V1 removed from home page to avoid page loading error.